### PR TITLE
update Example.v and include into CI

### DIFF
--- a/.github/workflows/from-sources.yml
+++ b/.github/workflows/from-sources.yml
@@ -23,6 +23,6 @@ jobs:
             opam upgrade -y
             opam install -y . --deps-only --with-test
             make
-            make test
+            make install.test
             make clean
             sudo chown -R 1001:116 .

--- a/.github/workflows/from-sources.yml
+++ b/.github/workflows/from-sources.yml
@@ -21,8 +21,8 @@ jobs:
             sudo chown -R 1000:1000 .
             opam update
             opam upgrade -y
-            opam install -y . --deps-only
+            opam install -y . --deps-only --with-test
             make
-            make install
+            make test
             make clean
             sudo chown -R 1001:116 .

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,17 @@ all: Makefile.coq
 install: Makefile.coq
 	make install -f Makefile.coq
 
-clean: Makefile.coq
-	make clean -f Makefile.coq
+clean: Makefile.coq.test
+	make clean -f Makefile.coq.test
 
 Makefile.coq : _CoqProject
 	coq_makefile -f _CoqProject -o Makefile.coq
+
+Makefile.coq.test : _CoqProject.test
+	coq_makefile -f _CoqProject.test -o Makefile.coq.test
+
+all.test: Makefile.coq.test
+	make all -f Makefile.coq.test
+
+install.test: Makefile.coq.test all.test
+	make install -f Makefile.coq.test

--- a/_CoqProject.test
+++ b/_CoqProject.test
@@ -1,0 +1,10 @@
+-Q theories Trakt
+-Q elpi Trakt.Elpi
+
+theories/InternalProofs.v
+theories/Database.v
+theories/Tactic.v
+theories/Commands.v
+theories/Trakt.v
+test/Unit.v
+example/Example.v

--- a/coq-trakt.opam
+++ b/coq-trakt.opam
@@ -14,6 +14,8 @@ depends: [
   "elpi" {>= "2.0"}
   "coq-elpi" {>= "2.3.0"}
   ("coq" {>= "8.20"} | "rocq-stdlib")
+    "coq-mathcomp-zify" {with-test}
+  ("rocq-mathcomp-algebra" | "coq-mathcomp-algebra") {with-test}
 ]
 tags: [ 
   "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"

--- a/coq-trakt.opam
+++ b/coq-trakt.opam
@@ -15,7 +15,7 @@ depends: [
   "coq-elpi" {>= "2.3.0"}
   ("coq" {>= "8.20"} | "rocq-stdlib")
     "coq-mathcomp-zify" {with-test}
-  ("rocq-mathcomp-algebra" | "coq-mathcomp-algebra") {with-test}
+  ("rocq-mathcomp-algebra" {with-test} | "coq-mathcomp-algebra" {with-test})
 ]
 tags: [ 
   "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"

--- a/example/Example.v
+++ b/example/Example.v
@@ -9,6 +9,7 @@
 
 From Coq Require Import ZArith ZifyClasses ZifyBool ZifyInst.
 From mathcomp.algebra Require Import ssrint.
+From mathcomp Require Import order.
 
 From mathcomp.zify Require Import ssrZ zify_algebra.
 Import AlgebraZifyInstances.
@@ -264,7 +265,7 @@ Proof.
   (* trakt Z Prop. *)
 Abort.
 
-Trakt Add Conversion Num.NumDomain.porderType.
+Trakt Add Conversion Order.POrder.Exports.porderType.
 
 Lemma Orderle_int_Zleb_equiv : forall (x y : int), x <= y = (Z_of_int x <=? Z_of_int y)%Z.
 Proof.
@@ -272,7 +273,7 @@ Proof.
 Qed.
 
 Trakt Add Relation 2
-  (@Order.le ring_display int_porderType)
+  (@Order.le ring_display int)
   Z.leb
   Orderle_int_Zleb_equiv.
 
@@ -310,7 +311,7 @@ Proof.
 Abort.
 
 (* ===== relation families ====================================================================== *)
-
+From Stdlib Require Import Vector.
 Definition bitvector n := Vector.t bool n.
 
 Module bitvector.

--- a/example/Example.v
+++ b/example/Example.v
@@ -8,7 +8,7 @@
  *)
 
 From Coq Require Import ZArith ZifyClasses ZifyBool ZifyInst.
-From mathcomp Require Import ssrint.
+From mathcomp.algebra Require Import ssrint.
 
 From mathcomp.zify Require Import ssrZ zify_algebra.
 Import AlgebraZifyInstances.
@@ -235,19 +235,21 @@ Proof.
   by move=> x y; split=> /eqP.
 Qed.
 
-Trakt Add Relation 2 (@eq_op int_eqType : int -> int -> bool) (@eq int) eqopint_eqint_equiv.
+Trakt Add Relation 2 (@eq_op _ : int -> int -> bool) (@eq int) eqopint_eqint_equiv.
 
 Trakt Add Relation 2 (@eq int) (@eq Z) eqint_eqZ_equiv.
 
 Local Open Scope ring_scope.
 
 Lemma intmul_Zmul_embed_eq : forall (x y : int),
-  Z_of_int (@intmul int_ZmodType x y) = (Z_of_int x * Z_of_int y)%Z.
+  Z_of_int (@intmul _ x y) = (Z_of_int x * Z_of_int y)%Z.
 Proof.
+  Set Printing Implicit.
+  Set Printing All.
   apply (@TBOpInj _ _ _ _ _ _ _ _ _ _ Op_int_intmul).
 Qed.
 
-Trakt Add Symbol (@intmul int_ZmodType) Z.mul intmul_Zmul_embed_eq.
+Trakt Add Symbol (@intmul _ :> int->int->int) Z.mul intmul_Zmul_embed_eq.
 
 Trakt Add Conversion GRing.add.
 Trakt Add Conversion GRing.mul.

--- a/theories/Commands.v
+++ b/theories/Commands.v
@@ -24,7 +24,6 @@ Elpi Query lp:{{
 }}.
 
 Elpi Accumulate File types.
-Elpi Typecheck.
 
 From Trakt Require Export Database.
 Elpi Accumulate Db embeddings.db.
@@ -33,10 +32,8 @@ Elpi Accumulate Db relations.db.
 Elpi Accumulate Db conversion.db.
 
 Elpi Accumulate File common.
-Elpi Typecheck.
 
 Elpi Accumulate File commands.
-Elpi Typecheck.
 
 Elpi Accumulate lp:{{
   pred elaborate-argument i:argument, o:argument.


### PR DESCRIPTION
Currently the CI does not include the `Example.v` which depends on `math-comp`. I have extended the CI to install math comp and then test the example.
The example was also a bit outdated so I have updated it. 

This is not yet ready to merge because CI is failing due to an apparent bug in Elpi, when this gets fixed we can perhaps merge it.